### PR TITLE
Wrap all potential JedisConnectionError with RepsheetCoonectionException

### DIFF
--- a/src/main/java/com/repsheet/librepsheet/Connection.java
+++ b/src/main/java/com/repsheet/librepsheet/Connection.java
@@ -3,6 +3,7 @@ package com.repsheet.librepsheet;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public class Connection {
     public enum Status { OK, ERROR }
@@ -50,7 +51,8 @@ public class Connection {
         return new Actor(type, value, Actor.Status.OK, null);
     }
 
-    public final Status blacklist(final String actor, final Actor.Type type, final String reason) {
+    public final Status blacklist(final String actor, final Actor.Type type, final String reason)
+    throws RepsheetConnectionException {
         String keyspace = Util.stringFromType(type);
         try (Jedis jedis = pool.getResource()) {
             if (keyspace == null) {
@@ -59,10 +61,13 @@ public class Connection {
                 jedis.set(actor + ":repsheet:" + keyspace + ":blacklisted", reason);
                 return Status.OK;
             }
+        } catch (JedisConnectionException e) {
+            throw new RepsheetConnectionException(e);
         }
     }
 
-    public final Status blacklist(final String actor, final Actor.Type type, final String reason, final int expiry) {
+    public final Status blacklist(final String actor, final Actor.Type type, final String reason, final int expiry)
+    throws RepsheetConnectionException {
         String keyspace = Util.stringFromType(type);
         try (Jedis jedis = pool.getResource()) {
             if (keyspace == null) {
@@ -71,10 +76,13 @@ public class Connection {
                 jedis.setex(actor + ":repsheet:" + keyspace + ":blacklisted", expiry, reason);
                 return Status.OK;
             }
+        } catch (JedisConnectionException e) {
+            throw new RepsheetConnectionException(e);
         }
     }
 
-    public final Status whitelist(final String actor, final Actor.Type type, final String reason) {
+    public final Status whitelist(final String actor, final Actor.Type type, final String reason)
+    throws RepsheetConnectionException {
         String keyspace = Util.stringFromType(type);
         try (Jedis jedis = pool.getResource()) {
             if (keyspace == null) {
@@ -83,10 +91,13 @@ public class Connection {
                 jedis.set(actor + ":repsheet:" + keyspace + ":whitelisted", reason);
                 return Status.OK;
             }
+        } catch (JedisConnectionException e) {
+            throw new RepsheetConnectionException(e);
         }
     }
 
-    public final Status whitelist(final String actor, final Actor.Type type, final String reason, final int expiry) {
+    public final Status whitelist(final String actor, final Actor.Type type, final String reason, final int expiry)
+    throws RepsheetConnectionException {
         String keyspace = Util.stringFromType(type);
         try (Jedis jedis = pool.getResource()) {
             if (keyspace == null) {
@@ -95,10 +106,13 @@ public class Connection {
                 jedis.setex(actor + ":repsheet:" + keyspace + ":whitelisted", expiry, reason);
                 return Status.OK;
             }
+        } catch (JedisConnectionException e) {
+            throw new RepsheetConnectionException(e);
         }
     }
 
-    public final Status mark(final String actor, final Actor.Type type, final String reason) {
+    public final Status mark(final String actor, final Actor.Type type, final String reason)
+    throws RepsheetConnectionException {
         String keyspace = Util.stringFromType(type);
         try (Jedis jedis = pool.getResource()) {
             if (keyspace == null) {
@@ -107,10 +121,13 @@ public class Connection {
                 jedis.set(actor + ":repsheet:" + keyspace + ":marked", reason);
                 return Status.OK;
             }
+        } catch (JedisConnectionException e) {
+            throw new RepsheetConnectionException(e);
         }
     }
 
-    public final Status mark(final String actor, final Actor.Type type, final String reason, final int expiry) {
+    public final Status mark(final String actor, final Actor.Type type, final String reason, final int expiry)
+    throws RepsheetConnectionException {
         String keyspace = Util.stringFromType(type);
         try (Jedis jedis = pool.getResource()) {
             if (keyspace == null) {
@@ -119,6 +136,8 @@ public class Connection {
                 jedis.setex(actor + ":repsheet:" + keyspace + ":marked", expiry, reason);
                 return Status.OK;
             }
+        } catch (JedisConnectionException e) {
+            throw new RepsheetConnectionException(e);
         }
     }
 }

--- a/src/main/java/com/repsheet/librepsheet/RepsheetConnectionException.java
+++ b/src/main/java/com/repsheet/librepsheet/RepsheetConnectionException.java
@@ -1,0 +1,17 @@
+package com.repsheet.librepsheet;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+public class RepsheetConnectionException extends JedisConnectionException {
+    public RepsheetConnectionException(String message) {
+        super(message);
+    }
+
+    public RepsheetConnectionException(Throwable cause) {
+        super(cause);
+    }
+
+    public RepsheetConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/repsheet/librepsheet/BadConnectionTest.java
+++ b/src/test/java/com/repsheet/librepsheet/BadConnectionTest.java
@@ -1,0 +1,80 @@
+package com.repsheet.librepsheet;
+
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+public class BadConnectionTest {
+    private Connection badConnection;
+
+    @Before
+    public void setUp() {
+        badConnection = new Connection("badhost");
+    }
+
+    @Test(expected = JedisConnectionException.class)
+    public void testConnectionReturnsUsableConnectionPoolShouldThrowUp() {
+        badConnection = new Connection("badhost");
+        badConnection.getPool().getResource();
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testBlacklistIPWithoutExpiryShouldThrowUp() {
+        badConnection.blacklist("1.1.1.1", Actor.Type.IP, "test");
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testBlacklistUserWithoutExpiryShouldThrowUp() {
+        badConnection.blacklist("repsheet", Actor.Type.USER, "test");
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testBlacklistIPWithExpiryShouldThrowUp() {
+        badConnection.blacklist("1.1.1.1", Actor.Type.IP, "test", 20);
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testBlacklistUserWithExpiryShouldThrowUp() {
+        badConnection.blacklist("repsheet", Actor.Type.USER, "test", 20);
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testWhitelistIPWithoutExpiryShouldThrowUp() {
+        badConnection.whitelist("1.1.1.1", Actor.Type.IP, "test");
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testWhitelistUserWithoutExpiryShouldThrowUp() {
+        badConnection.whitelist("repsheet", Actor.Type.USER, "test");
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testWhitelistIPWithExpiryShouldThrowUp() {
+        badConnection.whitelist("1.1.1.1", Actor.Type.IP, "test", 20);
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testWhitelistUserWithExpiryShouldThrowUp() {
+        badConnection.whitelist("repsheet", Actor.Type.USER, "test", 20);
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testMarkIPWithoutExpiryShouldThrowUp() {
+        badConnection.mark("1.1.1.1", Actor.Type.IP, "test");
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testMarkUserWithoutExpiryShouldThrowUp() {
+        badConnection.mark("repsheet", Actor.Type.USER, "test");
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testMarkIPWithExpiryShouldThrowUp() {
+        badConnection.mark("1.1.1.1", Actor.Type.IP, "test", 20);
+    }
+
+    @Test(expected = RepsheetConnectionException.class)
+    public void testMarkUserWithExpiryShouldThrowUp() {
+        badConnection.mark("repsheet", Actor.Type.USER, "test", 20);
+    }
+}


### PR DESCRIPTION
When using librepsheet, importing JedisConnectionException looks awkward. (My personal feeling). So I wrapped up every potential connection exception with Repsheet exception. What do you think?